### PR TITLE
Switch to the latest release of jsoniter-scala

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,8 +44,8 @@ lazy val purs = project.in(file("purs")).settings(
 
 lazy val benchmark = project.in(file("benchmark")).settings(
   libraryDependencies += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.10.0",
-  libraryDependencies += "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "1.0.0" % Compile,
-  libraryDependencies += "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "1.0.0" % Provided,
+  libraryDependencies += "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.0.1",
+  libraryDependencies += "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.0.1" % Provided,
   libraryDependencies += "io.suzaku" %% "boopickle" % "1.3.1",
   resolvers += Resolver.bintrayRepo("evolutiongaming", "maven"),
   libraryDependencies += "com.evolutiongaming" %% "kryo-macros" % "1.3.0",


### PR DESCRIPTION
...with more efficient parsing and serialization of Base16 representation:
```
[info] Benchmark                        Mode  Cnt        Score   Error  Units
[info] z.p.data.Decode.jsoniter_scala  thrpt    2   452137.824          ops/s
[info] z.p.data.Encode.jsoniter_scala  thrpt    2  1074555.397          ops/s
[info] z.p.msg.Decode.jsoniter_scala   thrpt    2  4341021.472          ops/s
[info] z.p.msg.Encode.jsoniter_scala   thrpt    2  8486618.088          ops/s
```