### PR TITLE
Fix example of dependency declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ jmh:run -i 5 -wi 2 -f1 -t1
 Add dependency:
 ```
 resolvers += Resolver.jcenterRepo
-libraryDependencies += "io.github.zero-deps" %% "proto-macros" % "latest.integration" % Compile
+libraryDependencies += "io.github.zero-deps" %% "proto-macros" % "latest.integration" % Provided
 libraryDependencies += "io.github.zero-deps" %% "proto-runtime" % "latest.integration"
 ```
 


### PR DESCRIPTION
Replacing `Compile` by `Provided` to avoid adding a transitive dependency of Scala reflection API which is required in compile time only for direct users of the library.