### PR TITLE
check-macros

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,7 +78,7 @@ ThisBuild / scalacOptions ++= {
       "-source", "future-migration", "-deprecation"
     , "release", "11"
     , "-Yexplicit-nulls"
-    // , "-Xcheck-macros" //todo: uncomment
+    , "-Xcheck-macros"
     )
   }
 }

--- a/proto/src/main/scala-3.0.0-RC2/BuildCodec.scala
+++ b/proto/src/main/scala-3.0.0-RC2/BuildCodec.scala
@@ -412,7 +412,7 @@ trait BuildCodec extends Common:
       val collectionCompanion = collectionType.typeSymbol.companionModule
       val builderTpe = builderType.appliedTo(List(tpe1, field.tpe))
       val sym = Symbol.newVal(Symbol.spliceOwner, s"${field.name}Read", builderTpe, Flags.EmptyFlags, Symbol.noSymbol)
-      val rhs = Select.unique(Ref(collectionCompanion), "newBuilder")
+      val rhs = Select.unique(Ref(collectionCompanion), "newBuilder").appliedToTypes(field.tpe.typeArgs)
       val init = ValDef(sym, Some(rhs))
       val ref = Ref(sym)
       init -> ref
@@ -426,7 +426,7 @@ trait BuildCodec extends Common:
   def resTerm(ref: Ref, field: FieldInfo): Term =
     if field.tpe.isOption then ref
     else if field.tpe.isIterable then
-      Select.unique(ref, "result")
+      Select.unique(ref, "result").appliedToNone
     else
       val error = s"missing required field `${field.name}: ${field.tpe.typeSymbol.name}`"
       val exception = '{ throw new RuntimeException(${Expr(error)}) }.asTerm

--- a/proto/src/main/scala-3.0.0-RC2/Common.scala
+++ b/proto/src/main/scala-3.0.0-RC2/Common.scala
@@ -43,7 +43,7 @@ trait Common:
             t.isIterable then 2
     else 2
 
-  def writeFun(os: Expr[CodedOutputStream], t: TypeRepr & Matchable, getterTerm: Term): Expr[Unit] =
+  def writeFun(os: Expr[CodedOutputStream], t: TypeRepr & Matchable, getterTerm: Term)(using Quotes): Expr[Unit] =
     if      t.isInt then '{ ${os}.writeInt32NoTag(${getterTerm.asExprOf[Int]}) }
     else if t.isLong then '{ ${os}.writeInt64NoTag(${getterTerm.asExprOf[Long]}) }
     else if t.isBoolean then '{ ${os}.writeBoolNoTag(${getterTerm.asExprOf[Boolean]}) }
@@ -67,7 +67,7 @@ trait Common:
     else if t.isBytesType then '{ CodedOutputStream.computeByteArraySizeNoTag(${getterTerm.asExprOf[IArray[Byte]]}.toArray) }
     else throwError(s"Unsupported common type: ${t.typeSymbol.name}")
 
-  def readFun(t: TypeRepr & Matchable, is: Expr[CodedInputStream]): Term =
+  def readFun(t: TypeRepr & Matchable, is: Expr[CodedInputStream])(using Quotes): Term =
     if      t.isInt then '{ ${is}.readInt32 }.asTerm
     else if t.isLong then '{ ${is}.readInt64 }.asTerm
     else if t.isBoolean then '{ ${is}.readBool }.asTerm

--- a/proto/src/main/scala-3.0.0-RC2/Common.scala
+++ b/proto/src/main/scala-3.0.0-RC2/Common.scala
@@ -145,7 +145,7 @@ trait Common:
       case AppliedType(t1, _) if t1.typeSymbol == OptionClass => true
       case _ => false
 
-    def typeArgs: List[TypeRepr] = t.matchable match
+    def typeArgs: List[TypeRepr] = t.dealias.matchable match
       case AppliedType(t1, args)  => args
       case _ => Nil
 

--- a/proto/src/main/scala-3.0.0-RC2/macrosapi.scala
+++ b/proto/src/main/scala-3.0.0-RC2/macrosapi.scala
@@ -56,7 +56,7 @@ private class Impl(using val qctx: Quotes) extends BuildCodec:
     )
     messageCodec(a_tpe, nums, params, restrictDefaults=true)
 
-  def caseCodecNums[A: Type](numsExpr: Expr[Seq[(String, Int)]]): Expr[MessageCodec[A]] =
+  def caseCodecNums[A: Type](numsExpr: Expr[Seq[(String, Int)]])(using Quotes): Expr[MessageCodec[A]] =
     val nums: Seq[(String, Int)] = numsExpr.valueOrError
     val a_tpe = getCaseClassType[A].matchable
     val aTypeSymbol = a_tpe.typeSymbol
@@ -92,7 +92,7 @@ private class Impl(using val qctx: Quotes) extends BuildCodec:
     numsExpr: Expr[Seq[(String, Int)]]
   )(
     constructor: Expr[Any]
-  ): Expr[MessageCodec[A]] =
+  )(using Quotes): Expr[MessageCodec[A]] =
     val nums: Seq[(String, Int)] = numsExpr.valueOrError
     val a_tpe = TypeRepr.of[A].matchable
     val aTypeSymbol = a_tpe.typeSymbol


### PR DESCRIPTION
Adding `-Xcheck-macros` (renamed `-Ycheck:macros`) to scalac options.